### PR TITLE
Get all commands extra values for rosa

### DIFF
--- a/rosa/cli.py
+++ b/rosa/cli.py
@@ -340,9 +340,3 @@ if __name__ == "__main__":
     """
     for local debugging.
     """
-    print(
-        build_command(
-            "delete operator-roles --cluster=24u8uorbgkfrearql3dn42ne49n1o3ju",
-            aws_region="east",
-        )
-    )

--- a/rosa/cli.py
+++ b/rosa/cli.py
@@ -72,10 +72,11 @@ def is_logged_in(aws_region=None, allowed_commands=None):
 
 def execute_command(command, wait_timeout=TIMEOUT_5MIN):
     log = f"Executing command: {' '.join(command)}, waiting for {wait_timeout} seconds."
-    LOGGER.info(hash_log_secrets(log=log, secrets=["token"]))
+    hashed_log = hash_log_secrets(log=log, secrets=["token"])
+    LOGGER.info(hashed_log)
     res = subprocess.run(command, capture_output=True, text=True, timeout=wait_timeout)
     if res.returncode != 0:
-        raise CommandExecuteError(f"Failed to execute: {res.stderr}")
+        raise CommandExecuteError(f"Failed to execute '{hashed_log}': {res.stderr}")
 
     return parse_json_response(response=res)
 
@@ -100,20 +101,23 @@ def build_command(command, allowed_commands=None, aws_region=None):
         _cmd for _cmd in _user_command if not _cmd.startswith(("--", "-"))
     ]
     commands_dict = benedict(_allowed_commands, keypath_separator=" ")
-    _output = commands_dict[commands_to_process]
+    commands_to_process_len = len(commands_to_process)
+    extra_commands = set()
+    for idx in range(commands_to_process_len):
+        _output = commands_dict[commands_to_process[: commands_to_process_len - idx]]
+        if _output.get("json_output") is True:
+            extra_commands.add("-ojson")
 
-    if _output.get("json_output") is True:
-        command.append("-ojson")
+        if _output.get("auto_answer_yes") is True:
+            extra_commands.add("--yes")
 
-    if _output.get("auto_answer_yes") is True:
-        command.append("--yes")
+        if _output.get("auto_mode") is True:
+            extra_commands.add("--mode=auto")
 
-    if _output.get("auto_mode") is True:
-        command.append("--mode=auto")
+        if _output.get("region") is True and aws_region:
+            extra_commands.add(f"--region={aws_region}")
 
-    if _output.get("region") is True and aws_region:
-        command.append(f"--region={aws_region}")
-
+    command.extend(extra_commands)
     return command
 
 
@@ -163,15 +167,56 @@ def parse_help(rosa_cmd="rosa"):
         commands_dict.setdefault(command, {})
 
     for top_command in commands_dict.keys():
+        # Always get top commands options
+        commands_dict[top_command]["json_output"] = check_flag_in_flags(
+            command_list=[rosa_cmd, top_command],
+            flag_str=output_flag_str,
+        )
+        commands_dict[top_command]["auto_answer_yes"] = check_flag_in_flags(
+            command_list=[rosa_cmd, top_command],
+            flag_str=auto_answer_yes_str,
+        )
+        commands_dict[top_command]["auto_mode"] = check_flag_in_flags(
+            command_list=[rosa_cmd, top_command],
+            flag_str=auto_mode_str,
+        )
+        commands_dict[top_command]["region"] = check_flag_in_flags(
+            command_list=[rosa_cmd, top_command],
+            flag_str=region_str,
+        )
+
         _commands = get_available_commands(command=[rosa_cmd, top_command])
 
         if _commands:
-            # If top command has sub command
             for command in _commands:
                 commands_dict[top_command][command] = {}
+                # Always get sub commands options
+                commands_dict[top_command][command][
+                    "json_output"
+                ] = check_flag_in_flags(
+                    command_list=[rosa_cmd, top_command, command],
+                    flag_str=output_flag_str,
+                )
+                commands_dict[top_command][command][
+                    "auto_answer_yes"
+                ] = check_flag_in_flags(
+                    command_list=[rosa_cmd, top_command, command],
+                    flag_str=auto_answer_yes_str,
+                )
+                commands_dict[top_command][command]["auto_mode"] = check_flag_in_flags(
+                    command_list=[rosa_cmd, top_command, command],
+                    flag_str=auto_mode_str,
+                )
+                commands_dict[top_command][command]["region"] = check_flag_in_flags(
+                    command_list=[rosa_cmd, top_command, command],
+                    flag_str=region_str,
+                )
+
                 _commands = get_available_commands(
                     command=[rosa_cmd, top_command, command]
                 )
+
+                # If top command has sub command
                 if _commands:
                     # If sub command has sub command
                     for _command in _commands:
@@ -200,49 +245,6 @@ def parse_help(rosa_cmd="rosa"):
                             command_list=[rosa_cmd, top_command, _command],
                             flag_str=region_str,
                         )
-                else:
-                    # If sub command doesn't have sub command
-                    commands_dict[top_command][command][
-                        "json_output"
-                    ] = check_flag_in_flags(
-                        command_list=[rosa_cmd, top_command, command],
-                        flag_str=output_flag_str,
-                    )
-                    commands_dict[top_command][command][
-                        "auto_answer_yes"
-                    ] = check_flag_in_flags(
-                        command_list=[rosa_cmd, top_command, command],
-                        flag_str=auto_answer_yes_str,
-                    )
-                    commands_dict[top_command][command][
-                        "auto_mode"
-                    ] = check_flag_in_flags(
-                        command_list=[rosa_cmd, top_command, command],
-                        flag_str=auto_mode_str,
-                    )
-                    commands_dict[top_command][command]["region"] = check_flag_in_flags(
-                        command_list=[rosa_cmd, top_command, command],
-                        flag_str=region_str,
-                    )
-
-        else:
-            # If top command doesn't have sub command
-            commands_dict[top_command]["json_output"] = check_flag_in_flags(
-                command_list=[rosa_cmd, top_command],
-                flag_str=output_flag_str,
-            )
-            commands_dict[top_command]["auto_answer_yes"] = check_flag_in_flags(
-                command_list=[rosa_cmd, top_command],
-                flag_str=auto_answer_yes_str,
-            )
-            commands_dict[top_command]["auto_mode"] = check_flag_in_flags(
-                command_list=[rosa_cmd, top_command],
-                flag_str=auto_mode_str,
-            )
-            commands_dict[top_command]["region"] = check_flag_in_flags(
-                command_list=[rosa_cmd, top_command],
-                flag_str=region_str,
-            )
 
     return commands_dict
 
@@ -338,3 +340,9 @@ if __name__ == "__main__":
     """
     for local debugging.
     """
+    print(
+        build_command(
+            "delete operator-roles --cluster=24u8uorbgkfrearql3dn42ne49n1o3ju",
+            aws_region="east",
+        )
+    )

--- a/rosa/tests/conftest.py
+++ b/rosa/tests/conftest.py
@@ -2,18 +2,17 @@ from rosa.cli import parse_help
 from rosa.tests.const import AWS_REGION_STR
 
 
-def path_from_dict(_dict, _path=""):
+def path_from_dict(_dict=None, _path=""):
     end_values = ["json_output", "auto_answer_yes", "auto_mode", "region"]
 
     for key, val in _dict.items():
-        # If dict == end_values we know that this is the final dict
-        if all([_key in end_values for _key in val.keys()]):
-            yield {
-                "command": f"{_path}{key}",
-                AWS_REGION_STR: AWS_REGION_STR if val["region"] else None,
-            }
-        else:
-            # If the command has sub command we need to get the syb command values
+        # If dict == end_values we need to test it
+        if isinstance(val, dict):
+            if all([_key in end_values for _key in val.keys()]):
+                yield {
+                    "command": f"{_path}{key}",
+                    AWS_REGION_STR: AWS_REGION_STR if val["region"] else None,
+                }
             yield from path_from_dict(_dict=val, _path=f"{key} ")
 
 


### PR DESCRIPTION
Get all `["json_output", "auto_answer_yes", "auto_mode", "region"]` values from all commands.
Some commands do not have it since the parent command have it .

For example, `rosa list oidc-config` do not have `--region` but `rosa list` have